### PR TITLE
[MER-1431] generate correct junit report

### DIFF
--- a/flakybot_pytest_runner/runner.py
+++ b/flakybot_pytest_runner/runner.py
@@ -42,6 +42,7 @@ class FlakybotRunner:
         junit_plugin = config.pluginmanager.getplugin("junitxml")
         if not junit_plugin:
             print("ERROR: use the --junitxml flag in your pytest run.")
+            return
         self.xml_key = junit_plugin.xml_key
 
     def pytest_terminal_summary(self, terminalreporter):
@@ -147,6 +148,7 @@ class FlakybotRunner:
             self.log_xml = self.config.stash.get(self.xml_key, None)
         if not self.log_xml:
             print("ERROR: use the --junitxml flag in your pytest run.")
+            return
         reporter = self.log_xml._opentestcase(report)
 
         # Do not increment FlakyTestAttributes on the test object here. This method is called during all test phases:


### PR DESCRIPTION
test run with max runs=5, min passes=2 -

<img width="1081" alt="Screen Shot 2022-11-01 at 9 12 31 PM" src="https://user-images.githubusercontent.com/13113118/199394087-31584c48-05da-4bd1-aa8f-f585820d6032.png">

corresponding junitxml -

<img width="1435" alt="Screen Shot 2022-11-01 at 9 13 20 PM" src="https://user-images.githubusercontent.com/13113118/199394160-57c796bd-ac3b-48e0-a819-84455ec87630.png">

another run, max runs=5, min passes=3 -
<img width="1169" alt="Screen Shot 2022-11-01 at 9 51 43 PM" src="https://user-images.githubusercontent.com/13113118/199401154-beab3997-8988-4161-ba39-322544dfd83b.png">

<img width="1169" alt="Screen Shot 2022-11-01 at 9 51 53 PM" src="https://user-images.githubusercontent.com/13113118/199401167-e61b4ecb-355f-4f0f-88bc-fd1cc0b98534.png">




junit -
<img width="1460" alt="Screen Shot 2022-11-01 at 9 51 32 PM" src="https://user-images.githubusercontent.com/13113118/199401130-d5c43829-4000-48cf-884c-3432bae5561e.png">


